### PR TITLE
support module.addOpens other at runtime

### DIFF
--- a/src/main/java/com/headius/modulator/Modulator.java
+++ b/src/main/java/com/headius/modulator/Modulator.java
@@ -17,6 +17,10 @@ public class Modulator {
         return new ModuleDummy();
     }
 
+    public static void addOpens​(Class<?> ownerClass, String pn, Class<?> otherClass) {
+        getModule(ownerClass).addOpens(pn, getModule(otherClass));
+    }
+
     public static <T extends AccessibleObject & Member> boolean trySetAccessible(T accessibleMember) {
         return trySetAccessible(accessibleMember.getDeclaringClass(), accessibleMember);
     }

--- a/src/main/java/com/headius/modulator/Module.java
+++ b/src/main/java/com/headius/modulator/Module.java
@@ -3,4 +3,5 @@ package com.headius.modulator;
 public interface Module {
     boolean isOpen(String pn);
     boolean isExported(String pn);
+    void addOpens(String pn, Module other);
 }

--- a/src/main/java/com/headius/modulator/impl/Module9.java
+++ b/src/main/java/com/headius/modulator/impl/Module9.java
@@ -1,5 +1,7 @@
 package com.headius.modulator.impl;
 
+import com.headius.modulator.Module;
+
 /**
  * Created by headius on 10/18/17.
  */
@@ -16,5 +18,9 @@ public class Module9 implements com.headius.modulator.Module {
 
     public boolean isExported(String pn) {
         return module.isExported(pn);
+    }
+
+    public void addOpens(String pn, Module other) {
+        module.addOpens(pn, ((Module9) other).module);
     }
 }

--- a/src/main/java/com/headius/modulator/impl/ModuleDummy.java
+++ b/src/main/java/com/headius/modulator/impl/ModuleDummy.java
@@ -13,4 +13,8 @@ public class ModuleDummy implements Module {
     public boolean isExported(String pn) {
         return true;
     }
+
+    public void addOpens(String pn, Module other) {
+        return;
+    }
 }


### PR DESCRIPTION
so we can open up sun.nio internals at runtime

e.g. `Modulator.addOpens(java.io.FileDescriptor.class, "sun.nio.ch", org.jruby.Ruby.class)`
would open-up the package (from FileDescriptor's owner - java.base module) for JRuby's module

... not super intuitive but using packages is even less clear